### PR TITLE
fix(plugin/command)：修复type类型错误

### DIFF
--- a/docs/zh/plugin/command.md
+++ b/docs/zh/plugin/command.md
@@ -92,6 +92,6 @@ php bin/hyperf.php mine-extension:create
 |---------------|---------|---------|------------------------------------|
 | path          | string | 无,必填    | 创建路径,例如 zds/app-store              | 
 | --name        | string | example | 插件名称                               |                        
-| --type        | string | mixed     | 插件类型 可选类型: mixed,frond,backend     |
+| --type        | string | mixed     | 插件类型 可选类型: mixed,frontend,backend     |
 | --author      | string| 无,可选    | 作者名称，此值会填充到 minejson.author 中      |
 | --description | string| 无,可选    | 插件介绍，此值会填充到 minejson.description 中 |


### PR DESCRIPTION
type类型front为frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the description of the `--type` parameter for the `mine-extension:create` command, updating "frond" to "frontend" in the list of allowed plugin types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->