### PR TITLE
Feat：优化AI 翻译脚本，并新增 日本语翻译支持  （孤儿文件显示 --未作任何处理）

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -92,7 +92,7 @@ jobs:
           cp docs/index.md docs/zh/index.md
           php bin/doc-translate
 
-      - name: Start Translate EN
+      - name: Start AI Translate (EN, JA)
         if: steps.changed-markdown-files.outputs.any_changed == 'true'
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-markdown-files.outputs.all_changed_files }}

--- a/bin/translate.js
+++ b/bin/translate.js
@@ -1,20 +1,48 @@
+// 执行参数
 import OpenAI from "openai";
 import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
-import path from 'path';
-import process from "process";
+import process from "node:process";
+import path from "path";
 
+process.noDeprecation = true;
 const endpoint = "https://api.deepseek.com";
-const token = process.env["DEEPSEEK_API_KEY"];
+const token = process.env["DEEPSEEK_API_KEY"] || '';
 const MAX_CONCURRENT = 10; // 最大并发数
 const MAX_RETRIES = 3; // 最大重试次数
-const ALL_CHANGED_FILES = process.env["ALL_CHANGED_FILES"];
+const CHANGE_FILES = process.env["CHANGE_FILES"]?.split('\n') ||  [];
+const SOURCE_DIRS = ['docs', '.vitepress/src'];
+const SOURCE_LANG = 'zh'; // 源语言
+
+const SUPPORTED_LANGUAGES = {
+    'en': {
+        name: 'English',
+        systemPrompt: {
+            md: 'You are a professional technical translator. Translate Simplified Chinese to English. Rules: do not change markdown syntax, code fences, inline code, front-matter keys, or link targets (URLs/paths). Do not translate code blocks. Only translate human-readable text. Do not add explanations.',
+            code: 'You are a professional technical translator. Translate only comments and string literals from Simplified Chinese to English. NEVER alter code tokens, identifiers, imports/exports, types, or file paths. Preserve formatting exactly. Do not add explanations.'
+        }
+    },
+    'ja': {
+        name: 'Japanese',
+        systemPrompt: {
+            md: 'You are a professional technical translator. Translate Simplified Chinese to Japanese. Rules: do not change markdown syntax, code fences, inline code, front-matter keys, or link targets (URLs/paths). Do not translate code blocks. Only translate human-readable text. Do not add explanations.',
+            code: 'You are a professional technical translator. Translate only comments and string literals from Simplified Chinese to Japanese. NEVER alter code tokens, identifiers, imports/exports, types, or file paths. Preserve formatting exactly. Do not add explanations.'
+        }
+    }
+};
+
+if (!token) {
+    console.error("❌ Please set the environment variable DEEPSEEK_API_KEY");
+    process.exit(1);
+}
 
 const openai = new OpenAI({
     baseURL: endpoint,
     apiKey: token,
 });
 
-async function translateWithRetry(content, retries = 0,systemContent = 'You are a professional translator. Translate the following Chinese markdown content to English. Keep all markdown formatting intact.') {
+
+// 业务函数定义开始
+async function translateWithRetry(content, retries = 0,systemContent = '') {
     try {
         const completion = await openai.chat.completions.create({
             messages: [
@@ -27,57 +55,136 @@ async function translateWithRetry(content, retries = 0,systemContent = 'You are 
     } catch (error) {
         if (retries < MAX_RETRIES) {
             await new Promise(resolve => setTimeout(resolve, 1000 * (retries + 1)));
-            return translateWithRetry(content, retries + 1,systemContent);
+            return translateWithRetry(content, retries + 1, systemContent);
         }
         throw error;
     }
 }
 
-async function processFile(srcPath, destPath) {
+async function readFiles(dir) {
+    let sources = await readdir(dir, { recursive: true });
+    return sources.filter(file => file.endsWith('.md') || file.endsWith('.js') || file.endsWith('.ts'));
+}
+
+function replaceZhLinks(content, lang) {
+    // Markdown 链接: [text](/zh/xxx)
+    content = content.replace(/(]\()\/zh\//g, `$1/${lang}/`);
+    // 行内链接: (/zh/xxx)
+    content = content.replace(/(\()\/zh\//g, `$1/${lang}/`);
+    // HTML 属性: href="/zh/xxx" 或 to="/zh/xxx"
+    content = content.replace(/(\b(?:href|to)=["'])\/zh\//g, `$1/${lang}/`);
+    return content;
+}
+
+async function processFile(srcPath, destPath, targetLang = 'en') {
     const destFolder = path.dirname(destPath);
     await mkdir(destFolder, { recursive: true });
     const content = await readFile(srcPath, 'utf8');
-    var systemContent = 'You are a professional translator. Translate the following Chinese markdown content to English. Keep all markdown formatting intact.';
-    if (srcPath.endsWith('.ts') || srcPath.endsWith('.js')) {
-        systemContent = 'You are a professional translator. Translate the following Chinese code content to English. Keep all code formatting intact.';
-    }else if (srcPath.endsWith('.md')) {
-        systemContent = 'You are a professional translator. Translate the following Chinese markdown content to English. Keep all markdown formatting intact.';
+
+    const langConfig = SUPPORTED_LANGUAGES[targetLang];
+    if (!langConfig) {
+        throw new Error(`Unsupported language: ${targetLang}`);
     }
-    const translatedContent = await translateWithRetry(content,0,systemContent);
-    const finalContent = translatedContent.replace(/\/zh\//g, '/en/');
+
+    let systemContent;
+    if (srcPath.endsWith('.ts') || srcPath.endsWith('.js')) {
+        systemContent = langConfig.systemPrompt.code;
+    } else if (srcPath.endsWith('.md')) {
+        systemContent = langConfig.systemPrompt.md;
+    } else {
+        systemContent = langConfig.systemPrompt.md; // 默认使用md提示
+    }
+
+    const translatedContent = await translateWithRetry(content, 0, systemContent);
+    const finalContent = replaceZhLinks(translatedContent, targetLang);
     await writeFile(destPath, finalContent);
-    console.log(`Translated: ${path.basename(srcPath)}`);
+    console.log(`✅ Translated: ${srcPath} to ${destPath}`);
 }
 
-async function translateFiles(srcDir, destDir) {
-    try {
-        const files = await readdir(srcDir, { recursive: true });
-        const mdFiles = files.filter(file => file.endsWith('.ts') || file.endsWith('.md'));
 
-        // 将文件分批处理
-        for (let i = 0; i < mdFiles.length; i += MAX_CONCURRENT) {
-            const batch = mdFiles.slice(i, i + MAX_CONCURRENT);
-            const promises = batch.map(file => {
-                // 如果指定了 ALL_CHANGED_FILES 环境变量，则只翻译发生变化的文件
-                if (ALL_CHANGED_FILES && !ALL_CHANGED_FILES.includes(file)) {
-                    console.log(`Skip translation for ${file}`);
-                    return;
-                }
-                const srcPath = path.join(srcDir, file);
-                const destPath = path.join(destDir, file);
-                return processFile(srcPath, destPath).catch(error => {
-                    console.error(`Error translating ${file}:`, error);
-                });
-            });
+async function handle() {
+    // 先扫描zh目录，获取所有需要处理的文件
+    let targetLanguages = Object.keys(SUPPORTED_LANGUAGES);
+    console.log(`🌐 Supported languages: ${targetLanguages.join(', ')}`);
+    console.log('----------------------------------------');
+    for (const dir of SOURCE_DIRS) {
+        let source_lang_dir = `${dir}/${SOURCE_LANG}`;
+        let sourceFiles;
 
-            await Promise.all(promises);
+        // 筛选出pr change files 在当前目录中
+        let changeInDirFiles = CHANGE_FILES
+            .filter(file => file.startsWith(source_lang_dir))
+            .map(file => file.replace(`${source_lang_dir}/`, ''));
+        console.log(`\n📁 Directory: ${dir}`);
+        try {
+            sourceFiles = await readFiles(source_lang_dir);
+            console.log(`  - ✅ Found ${sourceFiles.length} source files in ${source_lang_dir}`);
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                console.log(`  - 🟡 Source directory not found: ${source_lang_dir}`);
+                continue;
+            }
+            throw error;
         }
 
-        console.log('All translations completed!');
+        for (const lang of targetLanguages) {
+            if (lang === SOURCE_LANG) continue;
+            let target_lang_dir = `${dir}/${lang}`;
+            console.log(`  - 🌍 Language: ${lang}`);
+            try {
+                await mkdir(target_lang_dir, { recursive: true });
+                let targetFiles = await readFiles(target_lang_dir);
+                let filesToTranslate = sourceFiles.filter(file => !targetFiles.includes(file));
+                let orphanFiles = targetFiles.filter(file => !sourceFiles.includes(file));
+
+                // 合并 filesToTranslate 和 changeInDirFiles
+                let files = [...new Set([...changeInDirFiles, ...filesToTranslate])];
+
+                console.log(`    - 📝 Untranslated files: ${filesToTranslate.length}`);
+                console.log(`    - 🗑️ Orphan files: ${orphanFiles.length}`);
+                console.log(`    - 🔄 Change files: ${changeInDirFiles.length}`);
+                console.log(`    - 📂 Total files to translate: ${files.length}`);
+
+                if (files.length === 0) {
+                    console.log(`    - 🟢 No files to translate for ${lang}`);
+                    continue;
+                }
+
+                // 将文件分批处理
+                for (let i = 0; i < files.length; i += MAX_CONCURRENT) {
+                    const batch = files.slice(i, i + MAX_CONCURRENT);
+                    const promises = batch.map(file => {
+                        const srcPath = path.join(source_lang_dir, file);
+                        const destPath = path.join(target_lang_dir, file);
+                        return processFile(srcPath, destPath, lang).catch(error => {
+                            console.error(`❌ translating ${file}:`, error);
+                        });
+                    });
+
+                    await Promise.all(promises);
+                }
+                console.log(`✅ ${lang} translations completed!`);
+
+            } catch (error) {
+                if (error.code === 'ENOENT') {
+                    console.log(`    - 🟡 Target directory not found: ${target_lang_dir}`);
+                } else {
+                    throw error;
+                }
+            }
+        }
+        console.log('----------------------------------------');
+    }
+    console.log(`\n🎉 All translations completed!`);
+}
+
+async function main() {
+    try {
+        await handle();
     } catch (error) {
-        console.error('Translation error:', error);
+        console.error('❌ Error:', error.message);
+        process.exit(1);
     }
 }
 
-translateFiles('docs/zh', 'docs/en');
-translateFiles('.vitepress/src/zh', '.vitepress/src/en');
+await main();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@mineadmin/doc",
+  "type": "module",
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",


### PR DESCRIPTION
翻译逻辑 ：

1.    扫描源语言目录 获取所有md code 文件 (`docs/zh`,` .vitepress/src/zh` 目录)
2.    扫描目标语言目录 获取缺失翻译文件
3.    步骤2的结果 合并从ci 获取的 pr change files 
4.    调用AI翻译 并写入

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 自动翻译扩展为英文与日文，多目录扫描与按改动增量翻译，跳过未变更内容，提升效率与覆盖率。
  - 自动修正站内链接到目标语言路径，减少断链与维护成本。
  - 增强并发处理与进度报告，对缺失目录与错误更稳健；缺少 API Key 时提供明确提示。

- 杂务
  - 更新 GitHub Actions 步骤名称，便于识别 AI 翻译任务。
  - 项目切换为 ES Module 配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->