### PR TITLE
Style(NavBar): remove language switcher icon from navbar menu group

### DIFF
--- a/.vitepress/theme/styles/i18n-components.css
+++ b/.vitepress/theme/styles/i18n-components.css
@@ -62,13 +62,6 @@
   font-weight: 500;
 }
 
-/* Language switcher icons */
-.VPNavBarMenuGroup .text::before {
-  content: '🌐';
-  margin-right: 0.5rem;
-  font-size: 1.1em;
-}
-
 /* ========================================================================
    Navigation Bar Enhancements
    ======================================================================== */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 样式
  - 去除导航栏语言切换器文本前的“🌐”图标，界面更简洁，减少视觉干扰，并在浅色/深色主题下保持一致。
  - 文本对齐与间距已适配无图标状态，不影响现有布局与功能，其余语言切换器样式保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->