### PR TITLE
fix(ma-search): 修复搜索text配置错误，searchItems参数错误

### DIFF
--- a/.vitepress/theme/styles/enhancements.css
+++ b/.vitepress/theme/styles/enhancements.css
@@ -371,20 +371,20 @@
 .VPDoc input,
 .VPDoc textarea,
 .VPDoc select {
-  background: var(--vp-c-bg);
-  border: 1px solid var(--vp-c-border);
-  border-radius: 6px;
-  padding: 0.5rem 0.75rem;
-  color: var(--vp-c-text-1);
-  transition: border-color 0.2s ease;
+  /*background: var(--vp-c-bg);*/
+  /*border: 1px solid var(--vp-c-border);*/
+  /*border-radius: 6px;*/
+  /*padding: 0.5rem 0.75rem;*/
+  /*color: var(--vp-c-text-1);*/
+  /*transition: border-color 0.2s ease;*/
 }
 
 .VPDoc input:focus,
 .VPDoc textarea:focus,
 .VPDoc select:focus {
-  outline: none;
-  border-color: var(--vp-c-brand-1);
-  box-shadow: 0 0 0 2px var(--vp-c-brand-soft);
+  /*outline: none;*/
+  /*border-color: var(--vp-c-brand-1);*/
+  /*box-shadow: 0 0 0 2px var(--vp-c-brand-soft);*/
 }
 
 /* ===================================================================

--- a/.vitepress/theme/styles/i18n-components.css
+++ b/.vitepress/theme/styles/i18n-components.css
@@ -62,13 +62,6 @@
   font-weight: 500;
 }
 
-/* Language switcher icons */
-.VPNavBarMenuGroup .text::before {
-  content: '🌐';
-  margin-right: 0.5rem;
-  font-size: 1.1em;
-}
-
 /* ========================================================================
    Navigation Bar Enhancements
    ======================================================================== */

--- a/.vitepress/theme/styles/i18n-typography.css
+++ b/.vitepress/theme/styles/i18n-typography.css
@@ -200,7 +200,7 @@
 
 /* Content container width based on language */
 .VPDoc .vp-doc {
-  max-width: var(--content-width-normal);
+  /*max-width: var(--content-width-normal);*/
   margin: 0 auto;
   padding: 2rem 2.5rem 3rem;
 }
@@ -226,8 +226,8 @@
 /* CJK-specific paragraph justification */
 :root[lang^="zh"] .vp-doc p,
 :root[lang="ja"] .vp-doc p {
-  text-align: justify;
-  text-justify: inter-character;
+  /*text-align: justify;*/
+  /*text-justify: inter-character;*/
   word-break: keep-all;
   overflow-wrap: break-word;
   hyphens: none;

--- a/docs/demos/ma-search/collapsible-search/index.vue
+++ b/docs/demos/ma-search/collapsible-search/index.vue
@@ -87,11 +87,13 @@ const searchItems = ref([
     label: '状态',
     prop: 'status',
     render: 'select',
-    options: [
-      { label: '全部', value: '' },
-      { label: '启用', value: 1 },
-      { label: '禁用', value: 0 }
-    ]
+    renderProps: {
+      options: [
+        { label: '全部', value: '' },
+        { label: '启用', value: 1 },
+        { label: '禁用', value: 0 }
+      ]
+    }
   }
 ])
 
@@ -131,12 +133,14 @@ const moreSearchItems = ref([
     label: '部门',
     prop: 'department',
     render: 'select',
-    options: [
-      { label: '全部部门', value: '' },
-      { label: '技术部', value: 'tech' },
-      { label: '产品部', value: 'product' },
-      { label: '运营部', value: 'operation' }
-    ]
+    renderProps: {
+      options: [
+        { label: '全部部门', value: 'all' },
+        { label: '技术部', value: 'tech' },
+        { label: '产品部', value: 'product' },
+        { label: '运营部', value: 'operation' }
+      ]
+    }
   },
   {
     label: '职位',
@@ -161,10 +165,10 @@ const foldOptions1 = {
   fold: true,
   foldRows: 1,
   text: {
-    searchBtn: '搜索',
-    resetBtn: '重置',
-    isFoldBtn: '展开更多',
-    notFoldBtn: '收起'
+    searchBtn: () => '搜索',
+    resetBtn: () => '重置',
+    isFoldBtn: () => '展开更多',
+    notFoldBtn: () => '收起'
   }
 }
 
@@ -173,10 +177,10 @@ const foldOptions2 = {
   fold: true,
   foldRows: 3,
   text: {
-    searchBtn: '开始搜索',
-    resetBtn: '清空重置',
-    isFoldBtn: '显示全部条件',
-    notFoldBtn: '收起部分条件'
+    searchBtn: () => '开始搜索',
+    resetBtn: () => '清空重置',
+    isFoldBtn: () => '显示全部条件',
+    notFoldBtn: () => '收起部分条件'
   }
 }
 
@@ -191,7 +195,7 @@ const handleReset = (formData: any) => {
 }
 
 const handleFoldToggle = (state: boolean) => {
-  ElMessage(`搜索框${state ? '已折叠' : '已展开'}`)
+  ElMessage.info(`搜索框${state ? '已折叠' : '已展开'}`)
 }
 
 const toggleFold1 = () => {

--- a/docs/demos/ma-search/form-validation/index.vue
+++ b/docs/demos/ma-search/form-validation/index.vue
@@ -181,31 +181,41 @@ const basicValidationItems = ref<MaSearchItem[]>([
     label: '用户名',
     prop: 'username',
     render: 'input',
-    props: { placeholder: '请输入用户名' },
-    rules: [
-      { required: true, message: '用户名不能为空', trigger: 'blur' },
-      { min: 3, max: 20, message: '用户名长度在3-20个字符', trigger: 'blur' }
-    ]
+    renderProps: { placeholder: '请输入用户名' },
+    itemProps: {
+      rules: [
+        {required: true, message: '用户名不能为空', trigger: 'blur'},
+        {min: 3, max: 20, message: '用户名长度在3-20个字符', trigger: 'blur'}
+      ]
+    }
   },
   {
     label: '邮箱',
     prop: 'email',
     render: 'input',
-    props: { placeholder: '请输入邮箱地址' },
-    rules: [
-      { required: true, message: '邮箱不能为空', trigger: 'blur' },
-      { validator: validateEmail, trigger: 'blur' }
-    ]
+    renderProps: { placeholder: '请输入邮箱地址' },
+    itemProps: {
+      rules: [
+        { required: true, message: '邮箱不能为空', trigger: 'blur' },
+        { validator: validateEmail, trigger: 'blur' }
+      ]
+    }
   },
   {
     label: '年龄',
     prop: 'age',
-    render: 'input-number',
-    props: { min: 1, max: 120, placeholder: '请输入年龄' },
-    rules: [
-      { required: true, message: '年龄不能为空', trigger: 'blur' },
-      { validator: validateAge, trigger: 'change' }
-    ]
+    render: () => <el-input-number />,
+    renderProps: {
+      min: 1,
+      max: 120,
+      placeholder: '请输入年龄'
+    },
+    itemProps: {
+      rules: [
+        {required: true, message: '年龄不能为空', trigger: 'blur'},
+        {validator: validateAge, trigger: 'change'}
+      ]
+    }
   }
 ])
 
@@ -220,50 +230,58 @@ const advancedValidationItems = ref<MaSearchItem[]>([
     label: '手机号',
     prop: 'phone',
     render: 'input',
-    props: { placeholder: '请输入11位手机号' },
-    rules: [
-      { required: true, message: '手机号不能为空', trigger: 'blur' },
-      { validator: validatePhone, trigger: 'blur' }
-    ]
+    renderProps: { placeholder: '请输入11位手机号' },
+    itemProps: {
+      rules: [
+        {required: true, message: '手机号不能为空', trigger: 'blur'},
+        {validator: validatePhone, trigger: 'blur'}
+      ]
+    }
   },
   {
     label: '身份证号',
     prop: 'idcard',
     render: 'input',
-    props: { placeholder: '请输入身份证号' },
-    rules: [
-      { required: true, message: '身份证号不能为空', trigger: 'blur' },
-      { pattern: /(^\d{15}$)|(^\d{18}$)|(^\d{17}(\d|X|x)$)/, message: '身份证号格式不正确', trigger: 'blur' }
-    ]
+    renderProps: { placeholder: '请输入身份证号' },
+    itemProps: {
+      rules: [
+        {required: true, message: '身份证号不能为空', trigger: 'blur'},
+        {pattern: /(^\d{15}$)|(^\d{18}$)|(^\d{17}(\d|X|x)$)/, message: '身份证号格式不正确', trigger: 'blur'}
+      ]
+    }
   },
   {
     label: '工资范围',
     prop: 'salary_min',
-    render: 'input-number',
-    props: { min: 0, placeholder: '最低工资' },
-    rules: [
-      { type: 'number', message: '请输入数字', trigger: 'change' }
-    ]
+    render: () => <el-input-number />,
+    renderProps: { min: 0, placeholder: '最低工资' },
+    itemProps: {
+      rules: [
+        {type: 'number', message: '请输入数字', trigger: 'change'}
+      ]
+    }
   },
   {
     label: '到',
     prop: 'salary_max',
-    render: 'input-number',
-    props: { min: 0, placeholder: '最高工资' },
-    rules: [
-      { type: 'number', message: '请输入数字', trigger: 'change' },
-      {
-        validator: (rule: any, value: any, callback: any) => {
-          const formData = advancedValidationRef.value?.getSearchForm() || {}
-          if (value && formData.salary_min && value <= formData.salary_min) {
-            callback(new Error('最高工资必须大于最低工资'))
-          } else {
-            callback()
-          }
-        },
-        trigger: 'change'
-      }
-    ]
+    render: () => <el-input-number />,
+    renderProps: { min: 0, placeholder: '最高工资' },
+    itemProps: {
+      rules: [
+        {type: 'number', message: '请输入数字', trigger: 'change'},
+        {
+          validator: (rule: any, value: any, callback: any) => {
+            const formData = advancedValidationRef.value?.getSearchForm() || {}
+            if (value && formData.salary_min && value <= formData.salary_min) {
+              callback(new Error('最高工资必须大于最低工资'))
+            } else {
+              callback()
+            }
+          },
+          trigger: 'change'
+        }
+      ]
+    }
   }
 ])
 
@@ -277,21 +295,25 @@ const asyncValidationItems = ref<MaSearchItem[]>([
     label: '用户名',
     prop: 'async_username',
     render: 'input',
-    props: { placeholder: '输入用户名检查是否存在' },
-    rules: [
-      { required: true, message: '用户名不能为空', trigger: 'blur' },
-      { validator: asyncValidateUsername, trigger: 'blur' }
-    ]
+    renderProps: { placeholder: '输入用户名检查是否存在' },
+    itemProps: {
+      rules: [
+        {required: true, message: '用户名不能为空', trigger: 'blur'},
+        {validator: asyncValidateUsername, trigger: 'blur'}
+      ]
+    }
   },
   {
     label: '邮箱',
     prop: 'async_email',
     render: 'input',
-    props: { placeholder: '请输入邮箱' },
-    rules: [
-      { required: true, message: '邮箱不能为空', trigger: 'blur' },
-      { validator: validateEmail, trigger: 'blur' }
-    ]
+    renderProps: { placeholder: '请输入邮箱' },
+    itemProps: {
+      rules: [
+        {required: true, message: '邮箱不能为空', trigger: 'blur'},
+        {validator: validateEmail, trigger: 'blur'}
+      ]
+    }
   }
 ])
 
@@ -305,51 +327,57 @@ const conditionalValidationItems = ref<MaSearchItem[]>([
     label: '查询类型',
     prop: 'query_type',
     render: 'radio-group',
-    options: [
-      { label: '按用户名', value: 'username' },
-      { label: '按邮箱', value: 'email' },
-      { label: '按手机号', value: 'phone' }
-    ],
-    rules: [
-      { required: true, message: '请选择查询类型', trigger: 'change' }
-    ]
+    renderProps: {
+      options: [
+        {label: '按用户名', value: 'username'},
+        {label: '按邮箱', value: 'email'},
+        {label: '按手机号', value: 'phone'}
+      ],
+    },
+    itemProps: {
+      rules: [
+        {required: true, message: '请选择查询类型', trigger: 'change'}
+      ]
+    }
   },
   {
     label: '查询值',
     prop: 'query_value',
     render: 'input',
-    props: { placeholder: '请输入查询值' },
-    rules: [
-      { required: true, message: '查询值不能为空', trigger: 'blur' },
-      {
-        validator: (rule: any, value: any, callback: any) => {
-          if (!value) {
-            callback()
-            return
-          }
-          
-          const formData = conditionalValidationRef.value?.getSearchForm() || {}
-          const queryType = formData.query_type
-          
-          if (queryType === 'email' && !validateEmail(null, value, () => {})) {
-            callback(new Error('请输入正确的邮箱格式'))
-          } else if (queryType === 'phone' && !/^1[3-9]\d{9}$/.test(value)) {
-            callback(new Error('请输入正确的手机号格式'))
-          } else if (queryType === 'username' && (value.length < 3 || value.length > 20)) {
-            callback(new Error('用户名长度在3-20个字符'))
-          } else {
-            callback()
-          }
-        },
-        trigger: 'blur'
-      }
-    ]
+    renderProps: { placeholder: '请输入查询值' },
+    itemProps: {
+      rules: [
+        {required: true, message: '查询值不能为空', trigger: 'blur'},
+        {
+          validator: (rule: any, value: any, callback: any) => {
+            if (!value) {
+              callback()
+              return
+            }
+
+            const formData = conditionalValidationRef.value?.getSearchForm() || {}
+            const queryType = formData.query_type
+
+            if (queryType === 'email' && !validateEmail(null, value, () => {})) {
+              callback(new Error('请输入正确的邮箱格式'))
+            } else if (queryType === 'phone' && !/^1[3-9]\d{9}$/.test(value)) {
+              callback(new Error('请输入正确的手机号格式'))
+            } else if (queryType === 'username' && (value.length < 3 || value.length > 20)) {
+              callback(new Error('用户名长度在3-20个字符'))
+            } else {
+              callback()
+            }
+          },
+          trigger: 'blur'
+        }
+      ]
+    }
   },
   {
     label: '是否精确匹配',
     prop: 'exact_match',
     render: 'switch',
-    props: { activeText: '是', inactiveText: '否' }
+    renderProps: { activeText: '是', inactiveText: '否' }
   }
 ])
 

--- a/docs/demos/ma-search/methods-demo/index.vue
+++ b/docs/demos/ma-search/methods-demo/index.vue
@@ -198,39 +198,55 @@ const searchItems = ref<MaSearchItem[]>([
     label: '用户名',
     prop: 'username',
     render: 'input',
-    props: { placeholder: '请输入用户名', clearable: true },
-    rules: [{ required: true, message: '用户名不能为空', trigger: 'blur' }]
+    renderProps: {
+      placeholder: '请输入用户名',
+      clearable: true,
+    },
+    itemProps: {
+      rules: [
+          { required: true, message: '用户名不能为空', trigger: 'blur' }
+      ]
+    }
   },
   {
     label: '邮箱',
     prop: 'email',
     render: 'input',
-    props: { placeholder: '请输入邮箱', clearable: true },
-    rules: [
-      { required: true, message: '邮箱不能为空', trigger: 'blur' },
-      { type: 'email', message: '邮箱格式不正确', trigger: 'blur' }
-    ]
+    renderProps: {
+      placeholder: '请输入邮箱',
+      clearable: true,
+    },
+    itemProps: {
+      rules: [
+        { required: true, message: '邮箱不能为空', trigger: 'blur' },
+        { type: 'email', message: '邮箱格式不正确', trigger: 'blur' }
+      ]
+    }
   },
   {
     label: '状态',
     prop: 'status',
     render: 'select',
-    options: [
-      { label: '全部', value: '' },
-      { label: '启用', value: 1 },
-      { label: '禁用', value: 0 }
-    ]
+    renderProps: {
+      options: [
+        { label: '全部', value: '' },
+        { label: '启用', value: 1 },
+        { label: '禁用', value: 0 }
+      ]
+    }
   },
   {
     label: '部门',
     prop: 'department',
     render: 'select',
-    options: [
-      { label: '全部部门', value: '' },
-      { label: '技术部', value: 'tech' },
-      { label: '产品部', value: 'product' },
-      { label: '运营部', value: 'operation' }
-    ]
+    renderProps: {
+      options: [
+        { label: '全部部门', value: '' },
+        { label: '技术部', value: 'tech' },
+        { label: '产品部', value: 'product' },
+        { label: '运营部', value: 'operation' }
+      ]
+    }
   }
 ])
 
@@ -243,10 +259,10 @@ const searchOptions = ref({
   foldRows: 2,
   show: true,
   text: {
-    searchBtn: '搜索',
-    resetBtn: '重置',
-    isFoldBtn: '展开',
-    notFoldBtn: '收起'
+    searchBtn: () => '搜索',
+    resetBtn: () => '重置',
+    isFoldBtn: () => '展开',
+    notFoldBtn: () => '收起'
   }
 })
 

--- a/docs/demos/ma-search/table-integration/index.vue
+++ b/docs/demos/ma-search/table-integration/index.vue
@@ -184,47 +184,53 @@ const searchItems = ref<MaSearchItem[]>([
     label: '用户名',
     prop: 'username',
     render: 'input',
-    props: { placeholder: '请输入用户名', clearable: true }
+    renderProps: { placeholder: '请输入用户名', clearable: true }
   },
   {
     label: '邮箱',
     prop: 'email',
     render: 'input',
-    props: { placeholder: '请输入邮箱', clearable: true }
+    renderProps: {
+      placeholder: '请输入邮箱', clearable: true
+    }
   },
   {
     label: '手机号',
     prop: 'phone',
     render: 'input',
-    props: { placeholder: '请输入手机号', clearable: true }
+    renderProps: { placeholder: '请输入手机号', clearable: true }
   },
   {
     label: '部门',
     prop: 'department',
     render: 'select',
-    options: [
-      { label: '全部部门', value: '' },
-      { label: '技术部', value: 'tech' },
-      { label: '产品部', value: 'product' },
-      { label: '运营部', value: 'operation' },
-      { label: '市场部', value: 'marketing' }
-    ]
+    renderProps: {
+      options: [
+        { label: '全部部门', value: '' },
+        { label: '技术部', value: 'tech' },
+        { label: '产品部', value: 'product' },
+        { label: '运营部', value: 'operation' },
+        { label: '市场部', value: 'marketing' }
+      ]
+    }
   },
   {
     label: '状态',
     prop: 'status',
     render: 'select',
-    options: [
-      { label: '全部状态', value: '' },
-      { label: '启用', value: 1 },
-      { label: '禁用', value: 0 }
-    ]
+    renderProps: {
+      options: [
+        { label: '全部状态', value: '' },
+        { label: '启用', value: 1 },
+        { label: '禁用', value: 0 }
+      ]
+    }
   },
   {
     label: '创建时间',
     prop: 'created_at',
     render: 'date-picker',
-    props: { 
+    renderProps: {
       type: 'datetimerange', 
       placeholder: ['开始时间', '结束时间'],
       format: 'YYYY-MM-DD HH:mm:ss'
@@ -240,8 +246,8 @@ const searchOptions = {
   fold: true,
   foldRows: 2,
   text: {
-    searchBtn: '查询',
-    resetBtn: '重置'
+    searchBtn: () => '查询',
+    resetBtn: () => '重置'
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 样式
  - 移除 VPDoc 表单控件自定义样式，回退为浏览器默认外观。
  - 取消文档正文固定最大宽度，提升阅读弹性。
  - 禁用 CJK 段落强制两端对齐，改善排版可读性。
- 文档
  - MaSearch 示例统一为 renderProps/itemProps 配置结构。
  - 选择项迁移至 renderProps.options，数字输入改为函数渲染。
  - 按钮文案改为函数以支持动态文本，折叠提示调整为信息级别。
  - 个别选项默认值更新为 “all”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->